### PR TITLE
Update to core20 and gnome-3-38 snapcraft extension

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -13,7 +13,7 @@ description: |
 
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict
-base: core18
+base: core20
 
 # Launchpad doesn't recognize these fields yet
 passthrough:
@@ -30,42 +30,26 @@ slots:
 apps:
   gnome-mines:
     command: usr/bin/gnome-mines
-    extensions: [gnome-3-28]
-    plugs:
-      - gsettings
+    extensions: [ gnome-3-38 ]
     desktop: usr/share/applications/org.gnome.Mines.desktop
 
 parts:
   gnome-mines:
     source: https://gitlab.gnome.org/GNOME/gnome-mines.git
     source-type: git
+    source-tag: '40.0'
+    plugin: meson
+    meson-parameters: [ --prefix=/snap/gnome-mines/current/usr ]
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version $(git describe --tags --abbrev=10)
     override-build: |
-      sed -i.bak -e 's|=org.gnome.Mines$|=${SNAP}/meta/gui/org.gnome.Mines.svg|g' data/org.gnome.Mines.desktop.in
+      sed -i.bak -e 's|=org.gnome.Mines$|=${SNAP}/meta/gui/org.gnome.Mines.svg|g' $SNAPCRAFT_PART_SRC/data/org.gnome.Mines.desktop.in
       snapcraftctl build
       mkdir -p $SNAPCRAFT_PART_INSTALL/meta/gui/
       cp ../src/data/icons/hicolor/scalable/org.gnome.Mines.svg $SNAPCRAFT_PART_INSTALL/meta/gui/
       cp ../install/snap/gnome-mines/current/usr/share/applications/org.gnome.Mines.desktop $SNAPCRAFT_PART_INSTALL/meta/gui/
-    plugin: meson
-    meson-parameters: [--prefix=/snap/gnome-mines/current/usr]
     organize:
       snap/gnome-mines/current/usr: usr
     build-packages:
-      - gettext
-      - itstool
-      - libglib2.0-dev
-      - libgnome-games-support-1-dev
-      - libgtk-3-dev
-      - librsvg2-dev
       - libxml2-utils
-      - valac
-  libraries:
-    plugin: nil
-    stage-packages:
-      - libgnome-games-support-1-3
-      - libgee-0.8-2
-    prime:
-      - "usr/lib/*/libgnome-games-support-1.so.*"
-      - "usr/lib/x86_64-linux-gnu/libgee-0.8.so.*"


### PR DESCRIPTION
# Pull Request Template

## Description

Updated the base to core20 and the snapcraft extension to gnome-3-38, which removed the need for a lot of libraries, which shaved 200Kb from the snap.

## Type of change

Please check only the options that are relevant.

- [x] General maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I build this locally and tested it in an impish vm, both x11 and wayland. Looks great!

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings

